### PR TITLE
Quitar opción conflictiva de creación de env conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Aquí van los ambientes que se van a usar para el taller y competencia de Reinfo
 
 Para importar las dependencias de desarrollo para armar el taller corre el siguiente comando:
 ```
-conda env create -n rl-lab-dev --file dev-environment.yml
+conda env create --file dev-environment.yml
 ```
 Para activar este ambiente corre:
 ```


### PR DESCRIPTION
Dado que ya se encuentra en el file `dev-environment.yml`, la flag de
```
-n rl-lab-dev
```
me parece que es innecesaria y en el caso de Fedora Linux 39, es
conflictiva (al menos en Asahi Linux remix).

Esto resolvería #18, que fue el issue que abrí por esta razón, y que fue la sugerencia que dió @octavio-navarro 